### PR TITLE
[fix] bug do background da pagina de evento

### DIFF
--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -6,7 +6,7 @@
   top: -15px;
   #page-bg{
     position: relative;
-    background: url('/assets/event-bg.jpg') no-repeat center;
+    background: url('https://s3-sa-east-1.amazonaws.com/zionapp/images/event-bg.jpg') no-repeat center;
     background-size: cover;
     width: 100%;
     height: 400px;


### PR DESCRIPTION
Na pagina show evento a imagem de fundo estava faltando pois o
heroku nao armazena as imagens dos commits. Toda vez que fazemos
um push no heroku ele apaga os arquivos. Qualquer arquivo
armazenado deve ser colocado no amazon.