### PR TITLE
[fix] bug ao editar uma ala na tela de estaca

### DIFF
--- a/app/views/stakes/show.html.haml
+++ b/app/views/stakes/show.html.haml
@@ -20,7 +20,7 @@
       - @stake.wards.order(:name).each do |ward|
         .ui.clearing.segment
           = link_to ward.name, ward
-          = link_to edit_stake_path(ward),
+          = link_to edit_ward_path(ward),
             class: 'ui mini right floated icon button',
             title: 'Editar' do
             %i.edit.icon


### PR DESCRIPTION
Foi corrigido o bug de link de editar estaca ao inves de ala na
tela de visualização de estaca, nas listagem das alas da estacas.